### PR TITLE
ユーザー新規登録後自動ログインされるよう変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,8 +31,12 @@ class ApplicationController < ActionController::Base
   end
 
   def store_location
-    return unless !logged_in? && request.get? && !request.xhr? && !request.fullpath.match?(%r{/login|/users/new|/password_resets/new|/password_resets/edit|/emails/new|/emails/edit})
+    return if logged_in? || !request.get? || request.xhr? || request.fullpath.start_with?('/login', '/users/new', '/password_resets/', '/emails/')
 
     session[:previous_url] = request.fullpath
+  end
+
+  def after_login_path_for(_resource)
+    session[:previous_url] || root_path
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -12,10 +12,6 @@ class UserSessionsController < ApplicationController
     end
   end
 
-  def after_login_path_for(_resource)
-    session[:previous_url] || root_path
-  end
-
   def destroy
     logout
     redirect_to root_path, status: :see_other, notice: t('user_sessions.destroy.success')

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path, notice: t('users.create.success')
+      auto_login(@user)
+      redirect_to after_login_path_for(@user), notice: t('users.create.success')
     else
       flash.now[:alert] = t('users.create.failure')
       render :new, status: :unprocessable_entity

--- a/lib/tasks/import_shops.rake
+++ b/lib/tasks/import_shops.rake
@@ -23,7 +23,7 @@ namespace :shop do
   def search_shops(api_base_url, api_key)
     search_uri = URI("#{api_base_url}/textsearch/json")
     search_params = {
-      query: 'record shops in Ginza',
+      query: 'record shops in 横須賀',
       language: 'ja',
       type: 'store',
       key: api_key


### PR DESCRIPTION
# 概要
ユーザー新規登録後に自動でログインされるよう変更

## 内容
- ユーザー新規登録後のログインを省略し、自動でログイン状態にするよう変更
- ユーザー新規登録後のリダイレクト先を、新規登録フォームの直前のURLに変更(特定のURLを除く)
- Applicationコントローラーのstore_locationメソッドを修正