### PR TITLE
item作成・編集フォームに非同期バリデーションメッセージを追加

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,6 +16,9 @@ application.register("item-edit", ItemEditController)
 import ItemNewController from "./item_new_controller"
 application.register("item-new", ItemNewController)
 
+import ItemValidationController from "./item_validation_controller"
+application.register("item-validation", ItemValidationController)
+
 import MapController from "./map_controller"
 application.register("map", MapController)
 

--- a/app/javascript/controllers/item_validation_controller.js
+++ b/app/javascript/controllers/item_validation_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "field" ]
+
+  connect() {
+    this.setupValidation()
+    this.element.removeEventListener('submit', this.handleSubmit)
+    this.element.addEventListener('submit', this.handleSubmit.bind(this))
+  }
+
+  // フィールドの文字数が最大文字数を超えているかチェックする
+  checkFieldValidity(field) {
+    const maxLength = parseInt(field.dataset.maxLength)
+    if (field.value.length > maxLength) {
+      return `${maxLength}文字以内で入力してください`
+    }
+    return ''
+  }
+
+  // ターゲットのフィールドに入力されたフィールドの文字数が最大文字数を超えた場合エラーメッセージを表示
+  setupValidation() {
+    this.fieldTargets.forEach(field => {
+      let errorSpan = field.nextElementSibling
+      if (!errorSpan || !errorSpan.classList.contains('error-message')) {
+        errorSpan = document.createElement('span')
+        errorSpan.classList.add('error-message', 'text-primary', 'text-sm', 'mt-1')
+        field.parentNode.insertBefore(errorSpan, field.nextSibling)
+      }
+      
+      field.addEventListener('input', () => {
+        const errorMessage = this.checkFieldValidity(field)
+        errorSpan.textContent = errorMessage
+      })
+    })
+  }
+
+  // フィールドの文字数が最大文字数を超えている場合バリデーションメッセージを表示
+  handleSubmit(event) {
+    let isValid = true
+    this.fieldTargets.forEach(field => {
+      const errorMessage = this.checkFieldValidity(field)
+      if (errorMessage) {
+        isValid = false
+        field.setCustomValidity(errorMessage)
+      } else {
+        field.setCustomValidity('')
+      }
+    })
+
+    // バリデーションに引っかかった場合フォームの送信を防ぐ
+    if (!isValid) {
+      event.preventDefault()
+      this.element.reportValidity()
+    }
+  }
+}

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@
         <h2 class="text-2xl font-bold text-center mb-4"><%= t('.edit_want') %></h2>
     <% end %>
 
-    <%= form_with model: @item, local: true do |form| %>
+    <%= form_with model: @item, local: true, data: { controller: "item-validation" } do |form| %>
       <%= render 'shared/error_messages', object: form.object %>
 
       <div class="form-control">
@@ -17,7 +17,7 @@
           <span class="text-red-500 ml-2">*</span>
         </div>
         <% end %>
-        <%= form.text_field :title, value: @item.title&.name || params[:item]&.fetch(:title, nil), class: "input input-bordered text-base-100", required: true %>
+        <%= form.text_field :title, value: @item.title&.name || params[:item]&.fetch(:title, nil), class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" }, required: true %>
       </div>
 
       <div class="form-control">
@@ -27,22 +27,22 @@
             <span class="text-red-500 ml-2">*</span>
           </div>
         <% end %>
-        <%= form.text_field :artist_name, value: @item.artist_name&.name || params[:item]&.fetch(:artist_name, nil), class: "input input-bordered text-base-100", required: true %>
+        <%= form.text_field :artist_name, value: @item.artist_name&.name || params[:item]&.fetch(:artist_name, nil), class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" }, required: true %>
       </div>
 
       <div class="form-control">
         <%= form.label :release_format, class: "label" %>
-        <%= form.text_field :release_format, value: @item.release_format&.name || params[:item]&.fetch(:release_format, nil), class: "input input-bordered text-base-100" %>
+        <%= form.text_field :release_format, value: @item.release_format&.name || params[:item]&.fetch(:release_format, nil), class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" } %>
       </div>
 
       <div class="form-control">
         <%= form.label :press_country, class: "label" %>
-        <%= form.text_field :press_country, value: @item.press_country&.name || params[:item]&.fetch(:press_country, nil), class: "input input-bordered text-base-100" %>
+        <%= form.text_field :press_country, value: @item.press_country&.name || params[:item]&.fetch(:press_country, nil), class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" } %>
       </div>
 
       <div class="form-control">
         <%= form.label :matrix_number, class: "label" %>
-        <%= form.text_field :matrix_number, value: @item.matrix_number&.number || params[:item]&.fetch(:matrix_number, nil), class: "input input-bordered text-base-100" %>
+        <%= form.text_field :matrix_number, value: @item.matrix_number&.number || params[:item]&.fetch(:matrix_number, nil), class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" } %>
       </div>
 
       <div class="form-control">
@@ -63,7 +63,7 @@
 
       <div class="form-control">
         <%= form.label :tag, class: "label" %>
-        <%= form.text_field :tag, value: @item.tag_names, placeholder: t('items.placeholder.tag_input'), class: "input input-bordered text-base-100" %>
+        <%= form.text_field :tag, value: @item.tag_names, placeholder: t('items.placeholder.tag_input'), class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" } %>
       </div>
 
       <div class="form-control">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,7 +1,7 @@
 <%= stylesheet_link_tag 'custom_styles', media: 'all', 'data-turbolinks-track': 'reload' %>
 <div class="container mx-auto py-8 px-3 md:px-0">
   <div class="w-full max-w-md mx-auto bg-base-200 rounded-lg p-6 md:p-8">
-    <%= form_with model: @item, local: true do |form| %>
+    <%= form_with model: @item, local: true, data: { controller: "item-validation" } do |form| %>
       <%= render 'shared/error_messages', object: form.object %>
       <% if params[:role] %>
         <%= form.hidden_field :role, value: params[:role] %>
@@ -19,7 +19,7 @@
             <span class="text-red-500 ml-2">*</span>
           </div>
         <% end %>
-        <%= form.text_field :title, value: @title || params[:title], class: "input input-bordered text-base-100", required: true %>
+        <%= form.text_field :title, value: @title || params[:title], class: "input input-bordered w-full text-base-100", data: { max_length: 255, item_validation_target: "field" }, required: true %>
       </div>
 
       <div class="form-control">
@@ -29,22 +29,22 @@
             <span class="text-red-500 ml-2">*</span>
           </div>
         <% end %>
-        <%= form.text_field :artist_name, value: @artist_name || params[:artist_name], class: "input input-bordered text-base-100", required: true %>
+        <%= form.text_field :artist_name, value: @artist_name || params[:artist_name], class: "input input-bordered w-full text-base-100", data: { max_length: 255, item_validation_target: "field" }, required: true %>
       </div>
 
       <div class="form-control">
         <%= form.label :release_format, class: "label" %>
-        <%= form.text_field :release_format, value: @release_format || params[:release_format], class: "input input-bordered text-base-100" %>
+        <%= form.text_field :release_format, value: @release_format || params[:release_format], class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" } %>
       </div>
 
       <div class="form-control">
         <%= form.label :press_country, class: "label" %>
-        <%= form.text_field :press_country, value: @press_country || params[:press_country], class: "input input-bordered text-base-100" %>
+        <%= form.text_field :press_country, value: @press_country || params[:press_country], class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" } %>
       </div>
 
       <div class="form-control">
         <%= form.label :matrix_number, class: "label" %>
-        <%= form.text_field :matrix_number, value: @item.matrix_number&.number || params[:item]&.fetch(:matrix_number, nil), class: "input input-bordered text-base-100" %>
+        <%= form.text_field :matrix_number, value: @item.matrix_number&.number || params[:item]&.fetch(:matrix_number, nil), class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" } %>
       </div>
 
       <div class="form-control">
@@ -65,7 +65,7 @@
 
       <div class="form-control">
         <%= form.label :tag, class: "label" %>
-        <%= form.text_field :tag, value: @item.tag_names, placeholder: t('items.placeholder.tag_input'), class: "input input-bordered text-base-100" %>
+        <%= form.text_field :tag, value: @item.tag_names, placeholder: t('items.placeholder.tag_input'), class: "input input-bordered text-base-100", data: { max_length: 255, item_validation_target: "field" } %>
       </div>
 
       <div class="form-control">


### PR DESCRIPTION
# 概要
item作成・編集フォームに非同期でバリデーションメッセージを表示

## 内容
- item作成・編集フォームのバリデーションを管理するStimulusコントローラー（item-validation）を作成
- user_note以下の入力フィールドへのリアルタイムで文字数バリデーションを表示
- バリデーション失敗時のフォーム送信防止機能作成