### PR TITLE
item作成時に付属品が保存できないバグを修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -84,28 +84,28 @@ class ItemsController < ApplicationController
   end
 
   def build_item
-    item = current_user.items.build(item_params.except(:title, :artist_name, :release_format, :press_country, :matrix_number, :tag, accessory_ids: []))
+    item = current_user.items.build(item_params.except(:title, :artist_name, :release_format, :press_country, :matrix_number, :tag))
     item.find_or_create_related_objects(item_association_params)
     item
   end
 
   def save_item
-    accessory_names = params[:item][:accessory]&.split(',') || []
+    accessory_ids = params[:item][:accessory_ids]&.reject(&:blank?) || []
     tag_names = params[:item][:tag]&.split(',') || []
 
-    @item.save_with_accessories(accessory_names:) &&
-      @item.save_with_tags(tag_names:) &&
+    @item.accessory_ids = accessory_ids
+    @item.save_with_tags(tag_names:) &&
       @item.save
   end
 
   def update_item
     @item.find_or_create_related_objects(item_association_params)
 
-    accessory_names = params[:item][:accessory]&.split(',') || []
+    accessory_ids = params[:item][:accessory_ids]&.reject(&:blank?) || []
     tag_names = params[:item][:tag]&.split(',') || []
 
-    @item.save_with_accessories(accessory_names:) &&
-      @item.save_with_tags(tag_names:) &&
+    @item.accessory_ids = accessory_ids
+    @item.save_with_tags(tag_names:) &&
       @item.update(item_params.except(:title, :artist_name, :release_format, :press_country, :matrix_number, :tag, accessory_ids: []))
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -76,18 +76,4 @@ class Item < ApplicationRecord
   def tag_names
     tags.map(&:name).join(',')
   end
-
-  def save_with_accessories(accessory_names:)
-    ActiveRecord::Base.transaction do
-      self.accessories = accessory_names.map { |name| Accessory.find_or_initialize_by(name: name.strip) }
-      save!
-    end
-    true
-  rescue StandardError
-    false
-  end
-
-  def accessory_names
-    accessories.map(&:name).join(',')
-  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -43,8 +43,8 @@
     <div class="grid grid-cols-2 gap-4 items-start py-1 rounded-lg text-accent text-sm md:text-base">
       <span><%= t('items.show.accessory') %></span>
       <div>
-        <% @item.accessory_names.split(',').each do |accessory_name| %>
-          <span class="badge badge-secondary text-sm md:text-base"><%= accessory_name.strip %></span>
+        <% @item.accessories.each do |accessory| %>
+          <span class="badge badge-secondary text-sm md:text-base"><%= accessory.name %></span>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
# 概要
item作成時に付属品が保存できないバグを修正

## 内容
#### Itemsコントローラー
- build_itemメソッドのaccessory_ids`パラメータの除外を解除
- save_itemメソッドを修正
   - accessoryの保存方法をaccessory_idsの直接設定に変更
- update_itemメソッドを修正
   - アクセサリーの処理をsave_itemメソッドと一致させた

#### Itemモデル
- save_with_accessories(accessory_names:)メソッドとaccessory_namesメソッドを削除

#### item_show
- accessoryの表示方法を改善
  - モデルの関連付けを直接利用
  - 文字列操作（split, strip）を削除し、データベースから直接取得したオブジェクトを使用するよう変更