### PR TITLE
Recordモデルスペック修正

### DIFF
--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -9,15 +9,6 @@ RSpec.describe Record, type: :model do
     end
   end
 
-  context '関連するitemがない場合' do
-    it '無効であること' do
-      record = build(:record)
-      record.items = []
-      expect(record).to be_invalid
-      expect(record.errors[:items]).to include('を入力してください')
-    end
-  end
-
   context 'コメントが10000文字以下の場合' do
     it '有効であること' do
       record = build(:review, content: 'a' * 10000)


### PR DESCRIPTION
# 概要
Recordモデルスペック修正

## 内容
Recordモデルのitems必須バリデーションを削除したため、recordに紐づくitemsがない場合のテストを削除した。
recordに紐づくitemsがない場合、非同期でアラートを表示するため、Recordシステムスペックでテストを実施している。