### PR TITLE
Select2コンポーネントの初期化/破棄処理の修正

### DIFF
--- a/app/javascript/controllers/item_edit_controller.js
+++ b/app/javascript/controllers/item_edit_controller.js
@@ -11,13 +11,23 @@ export default class extends Controller {
 
   initializeSelect2() {
     $(this.element).find('.select2').each(function() {
-      $(this).select2();
+      // select2が未初期化の場合のみ初期化
+      if (!$(this).data('select2')) {
+        $(this).select2();
+      }
     });
   }
 
   destroySelect2() {
     $(this.element).find('.select2').each(function() {
-      $(this).select2('destroy');
+      try {
+        // select2が初期化されている場合のみ破棄処理を行う
+        if ($(this).data('select2')) {
+          $(this).select2('destroy');
+        }
+      } catch (e) {
+        console.warn('Failed to destroy Select2:', e);
+      }
     });
   }
 }

--- a/app/javascript/controllers/item_new_controller.js
+++ b/app/javascript/controllers/item_new_controller.js
@@ -6,6 +6,16 @@ export default class extends Controller {
   }
 
   disconnect() {
-    $(this.element).find('.select2').select2('destroy');
+    $(this.element).find('.select2').each(function() {
+      try {
+        // Select2が初期化されているか確認
+        if ($(this).data('select2')) {
+          // Select2インスタンスを破棄する
+          $(this).select2('destroy');
+        }
+      } catch (e) {
+        console.warn('Failed to destroy Select2:', e);
+      }
+    });
   }
 }


### PR DESCRIPTION
# 概要
未初期化のSelect2インスタンスに対してdestroyメソッドを呼び出した際に発生するエラーを修正

## 内容
#### item_new_controller.js / item_edit_controller.js
- Select2の初期化状態チェックを追加し、初期化されている場合のみdestroyメソッドが呼び出されるよう修正

