### PR TITLE
CarrierWaveの設定から非推奨となったfog_providerの設定を削除

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -4,7 +4,6 @@ require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
     config.storage :fog
-    config.fog_provider = 'fog/aws'
     config.fog_directory  = 'vinyllog1'
     config.fog_credentials = {
       provider: 'AWS',


### PR DESCRIPTION
# 概要
CarrierWaveの設定から非推奨となったfog_providerの設定を削除

## 内容
config/initializers/carrierwave.rbの設定を修正
- 非推奨となった`config.fog_provider = 'fog/aws'`の行を削除
- その他のAWS S3関連の設定はそのまま維持