### PR TITLE
独自ドメインの設定を追加

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 class UserMailer < ApplicationMailer
-  default_url_options[:host] = 'vinyllog-233013640988.herokuapp.com'
+  default_url_options[:host] = 'vinyllog.jp'
 
   def reset_password_email(user)
     @user = User.find(user.id)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -95,6 +95,4 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
-
-  config.hosts << 'vinyllog-233013640988.herokuapp.com'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,14 +74,14 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "findvinyl_production"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 'vinyllog-233013640988.herokuapp.com' }
+  config.action_mailer.default_url_options = { host: 'vinyllog.jp' }
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:              'smtp.gmail.com',
     port:                 587,
-    domain:               'vinyllog-233013640988.herokuapp.com',
+    domain:               'vinyllog.jp',
     user_name:            ENV['GMAIL_USERNAME'],
     password:             ENV['GMAIL_PASSWORD'],
     authentication:       'plain',
@@ -112,5 +112,6 @@ Rails.application.configure do
 
   config.cache_classes = true
 
-  config.hosts << 'vinyllog-233013640988.herokuapp.com'
+  config.hosts << 'vinyllog.jp'
+  config.hosts << 'www.vinyllog.jp'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,5 +113,4 @@ Rails.application.configure do
   config.cache_classes = true
 
   config.hosts << 'vinyllog.jp'
-  config.hosts << 'www.vinyllog.jp'
 end


### PR DESCRIPTION
# 概要
独自ドメインの設定を追加

## 内容
- Action Mailerのデフォルトホストをvinyllog.jpに変更
- SMTPのドメイン設定をvinyllog.jpに変更
- 許可するホストリストを独自ドメインに変更