### PR TITLE
item編集フォームのレイアウト修正

### DIFF
--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -53,7 +53,8 @@
       </div>
 
       <div data-controller="item-edit">
-          <%= form.label :accessories, for: "item_accessory_ids", class: "label" %>
+        <div class="form-control">
+        <%= form.label :accessories, for: "item_accessory_ids", class: "label" %>
           <%= form.select :accessory_ids, 
                           @accessories.map { |accessory| [accessory.name, accessory.id] }, {}, 
                           {class: "select2 text-base-100", multiple: true, id: "item_accessory_ids"} %>


### PR DESCRIPTION
# 概要
item編集フォームのレイアウト崩れ修正

## 内容
付属品選択フィールドの `form-control` クラスが抜けていたため追加